### PR TITLE
add MIT license metadata to gemspec

### DIFF
--- a/expression_parser.gemspec
+++ b/expression_parser.gemspec
@@ -12,6 +12,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = "http://github.com/nricciar/expression_parser"
   s.platform = Gem::Platform::RUBY
   s.summary = "Math parser based on Lukasz Wrobel's blog post"
+  s.license = "MIT"
   s.files = `git ls-files`.split("\n")
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_path = "lib"


### PR DESCRIPTION
This pull request allows RubyGems.org and other tools (such as gem2rpm) to report a license for your gem.
